### PR TITLE
Ignore NavigationDuplicated from router in Search

### DIFF
--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -98,7 +98,7 @@
                         query: this.settings
                     });
                 else
-                    this.$router.push('/');
+                    this.$router.push('/').catch(() => {}); // Ignore NavigationDuplicated
                 this.isTyping = false;
             }, 500),
 


### PR DESCRIPTION
The component would push the current location, and the router would
throw a (very unhelpful) error.

See
https://github.com/vuejs/vue-router/issues/2881#issuecomment-520554378